### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+build/
+Build/
+Output/
+*.nso
+*.nro
+*.nsp
+*.elf
+.vscode/
+.vs/
+bin/
+obj/
+target/
+.settings/
+.classpath
+.project


### PR DESCRIPTION
evita mierda innecesaria en el repo, como la carpeta build